### PR TITLE
Fixes #5 - Define a constant instead of duplicating this literal "MouseClick" 3 times

### DIFF
--- a/jme3-android-examples/src/main/java/jme3test/android/TestAndroidSensors.java
+++ b/jme3-android-examples/src/main/java/jme3test/android/TestAndroidSensors.java
@@ -35,6 +35,7 @@ import java.util.logging.Logger;
 public class TestAndroidSensors extends SimpleApplication implements ActionListener, AnalogListener {
 
     private static final Logger logger = Logger.getLogger(TestAndroidSensors.class.getName());
+    private static final String MOUSE_CLICK = "MouseClick";
 
     private Geometry geomZero = null;
     // Map of joysticks saved with the joyId as the key
@@ -134,8 +135,8 @@ public class TestAndroidSensors extends SimpleApplication implements ActionListe
 
         // Touch (aka MouseInput.BUTTON_LEFT) is used to record the starting
         // orientation when using absolute rotations
-        inputManager.addMapping("MouseClick", new MouseButtonTrigger(MouseInput.BUTTON_LEFT));
-        inputManager.addListener(this, "MouseClick");
+        inputManager.addMapping(MOUSE_CLICK, new MouseButtonTrigger(MouseInput.BUTTON_LEFT));
+        inputManager.addListener(this, MOUSE_CLICK);
 
         Joystick[] joysticks = inputManager.getJoysticks();
         if (joysticks == null || joysticks.length < 1) {
@@ -230,7 +231,7 @@ public class TestAndroidSensors extends SimpleApplication implements ActionListe
 
     @Override
     public void onAction(String string, boolean pressed, float tpf) {
-       if (string.equalsIgnoreCase("MouseClick") && pressed) {
+       if (string.equalsIgnoreCase(MOUSE_CLICK) && pressed) {
             // Calibrate the axis (set new zero position) if the axis
             // is a sensor joystick axis
             for (IntMap.Entry<Joystick> entry : joystickMap) {


### PR DESCRIPTION
[SonarCloud Issue](https://sonarcloud.io/project/issues?open=AZTTKbLqKmNv4KQukksN&id=SOEN6431WINTER25_jmonkeyengineW25)

The pull request addresses the duplication of the literal "MouseClick" in TestAndroidSensors.java by defining a constant MOUSE_CLICK. This change avoids duplication and enhances the code's readability and maintainability.

**Key Changes:**
MOUSE_CLICK: Defined a constant to replace all occurrences of the literal "MouseClick".
"MouseClick": Removed all redundant and identical string literals.

**Benefits:**
Reduced Cognitive Load: Using a constant minimizes errors and simplifies the process of making future changes to the string value.
Improved Maintainability: Isolating repetitive string literals into well-defined constants allows for easier updates and better code readability.

**Conclusion**
This refactoring successfully addresses the duplicated string literal "MouseClick", enhancing maintainability, reducing redundancy, and improving code clarity.