### PR TITLE
Refactored duplicate Matrix3f serialization logic to remove duplication

### DIFF
--- a/jme3-core/src/main/java/com/jme3/shader/bufferobject/layout/RawLayout.java
+++ b/jme3-core/src/main/java/com/jme3/shader/bufferobject/layout/RawLayout.java
@@ -396,20 +396,7 @@ public class RawLayout extends BufferLayout {
 
             @Override
             public void write(BufferLayout serializer, ByteBuffer bbf, Matrix3f obj) {
-                obj.getColumn(0, tmp);
-                bbf.putFloat(tmp.x);
-                bbf.putFloat(tmp.y);
-                bbf.putFloat(tmp.z);
-
-                obj.getColumn(1, tmp);
-                bbf.putFloat(tmp.x);
-                bbf.putFloat(tmp.y);
-                bbf.putFloat(tmp.z);
-
-                obj.getColumn(2, tmp);
-                bbf.putFloat(tmp.x);
-                bbf.putFloat(tmp.y);
-                bbf.putFloat(tmp.z);
+                writeMatrix3fToBuffer(bbf, obj, tmp);
             }
         });
 
@@ -471,20 +458,7 @@ public class RawLayout extends BufferLayout {
             @Override
             public void write(BufferLayout serializer, ByteBuffer bbf, Matrix3f[] objs) {
                 for (Matrix3f obj : objs) {
-                    obj.getColumn(0, tmp);
-                    bbf.putFloat(tmp.x);
-                    bbf.putFloat(tmp.y);
-                    bbf.putFloat(tmp.z);
-
-                    obj.getColumn(1, tmp);
-                    bbf.putFloat(tmp.x);
-                    bbf.putFloat(tmp.y);
-                    bbf.putFloat(tmp.z);
-
-                    obj.getColumn(2, tmp);
-                    bbf.putFloat(tmp.x);
-                    bbf.putFloat(tmp.y);
-                    bbf.putFloat(tmp.z);
+                    writeMatrix3fToBuffer(bbf, obj, tmp);
                 }
             }
         });
@@ -533,6 +507,15 @@ public class RawLayout extends BufferLayout {
             }
         });
 
+    }
+
+    private void writeMatrix3fToBuffer(ByteBuffer bbf, Matrix3f obj, Vector3f tmp) {
+        for (int i = 0; i < 3; i++) {
+            obj.getColumn(i, tmp);
+            bbf.putFloat(tmp.x);
+            bbf.putFloat(tmp.y);
+            bbf.putFloat(tmp.z);
+        }
     }
 
     @Override


### PR DESCRIPTION
### Changes Implemented:
- Added `writeMatrix3fToBuffer` helper method to remove redundancy.
- Refactored `write` method for `Matrix3f` serializer (line 398) to use the helper method.
- Refactored `write` method for `Matrix3f[]` serializer (line 473) to use the helper method.
- Ensured the helper method is placed correctly for maintainability.
- Verified changes to reduce PMD-reported code duplication.

**Impact of Changes:**
- Improves maintainability and readability.
- Reduces duplicate code and enhances reusability.
- Ensures better compliance with PMD rules.
