### PR TITLE
Refactor byte array conversion in MjpegFileWriter.java using MjpegUtils

### DIFF
--- a/jme3-android/src/main/java/com/example/utils/AVIIndex.java
+++ b/jme3-android/src/main/java/com/example/utils/AVIIndex.java
@@ -1,0 +1,13 @@
+package com.example.utils;
+
+public class AVIIndex {
+    public byte[] fcc = new byte[]{'0', '0', 'd', 'b'};
+    public int dwFlags = 16;
+    public int dwOffset;
+    public int dwSize;
+
+    public AVIIndex(int dwOffset, int dwSize) {
+        this.dwOffset = dwOffset;
+        this.dwSize = dwSize;
+    }
+}

--- a/jme3-android/src/main/java/com/example/utils/MjpegUtils.java
+++ b/jme3-android/src/main/java/com/example/utils/MjpegUtils.java
@@ -1,0 +1,10 @@
+package com.example.utils;
+
+import java.io.ByteArrayOutputStream;
+
+public class MjpegUtils {
+    // Utility method to convert ByteArrayOutputStream to byte array
+    public static byte[] toByteArray(ByteArrayOutputStream baos) {
+        return baos.toByteArray();
+    }
+}

--- a/jme3-android/src/main/java/com/jme3/app/state/MjpegFileWriter.java
+++ b/jme3-android/src/main/java/com/jme3/app/state/MjpegFileWriter.java
@@ -42,6 +42,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import com.example.utils.MjpegUtils;  
+
 
 /**
  * Released under BSD License
@@ -486,7 +488,7 @@ public class MjpegFileWriter {
 
             baos.close();
 
-            return baos.toByteArray();
+            return MjpegUtils.toByteArray(baos);
         }
     }
 

--- a/jme3-android/src/main/java/com/jme3/app/state/MjpegFileWriter.java
+++ b/jme3-android/src/main/java/com/jme3/app/state/MjpegFileWriter.java
@@ -42,7 +42,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import com.example.utils.MjpegUtils;  
+import com.example.utils.MjpegUtils;
+import com.example.utils.AVIIndex;
 
 
 /**
@@ -512,7 +513,7 @@ public class MjpegFileWriter {
             baos.write(intBytes(swapInt(dwSize)));
             baos.close();
 
-            return baos.toByteArray();
+           return MjpegUtils.toByteArray(baos);
         }
     }
 


### PR DESCRIPTION
**Description:**
This pull request refactors the redundant byte array conversion logic in MjpegFileWriter.java. The duplicated code has been replaced with a call to the shared utility method MjpegUtils.toByteArray(), which consolidates the byte array conversion logic into one reusable method, improving maintainability and reducing code duplication.

**Changes:**
	•	Replaced baos.toByteArray() with MjpegUtils.toByteArray(baos) in line 497 of MjpegFileWriter.java.
	•	The byte array conversion logic is now handled by the utility class MjpegUtils, which has been created to centralize commonly used functionality.

**Why this change?**

**This refactor:**
	•	Reduces code duplication by centralizing the byte array conversion logic in the utility class.
	•	Improves code maintainability by using a single method for byte conversion, making it easier to update and manage in the future.

**Testing:**
	•	After refactoring, the code was tested locally to ensure the byte array conversion works as expected and there were no regressions in the functionality.