### PR TITLE
Update Bone.java

### DIFF
--- a/jme3-core/src/main/java/com/jme3/animation/Bone.java
+++ b/jme3-core/src/main/java/com/jme3/animation/Bone.java
@@ -303,8 +303,10 @@ public final class Bone implements Savable, JmeCloneable {
      */
     @Deprecated
     public Vector3f getWorldBindInversePosition() {
-        return modelBindInversePos;
+        return modelBindInversePos.clone();  // Return a clone (defensive copy) of the Vector3f
     }
+    
+
 
     /**
      * Returns the inverse Bind position of this bone expressed in model space.


### PR DESCRIPTION
The method `getWorldBindInversePosition()` was returning a reference to the mutable `modelBindInversePos` object, which could expose the internal state of the `Bone` class to external modifications. To prevent this issue, the method was updated to return a defensive copy of `modelBindInversePos` instead, ensuring the internal state remains protected from external changes.

This change enhances encapsulation and prevents unintended side effects caused by mutable object exposure.