### PR TITLE
Fixed software Vunerability issue

### DIFF
--- a/jme3-awt-dialogs/src/main/java/com/jme3/awt/AWTErrorDialog.java
+++ b/jme3-awt-dialogs/src/main/java/com/jme3/awt/AWTErrorDialog.java
@@ -48,8 +48,8 @@ import javax.swing.JTextArea;
  * @author kwando
  */
 public class AWTErrorDialog extends JDialog {
-    public static String DEFAULT_TITLE = "Error in application";
-    public static int PADDING = 8;
+    public static final String DEFAULT_TITLE = "Error in application";
+    public static final int PADDING = 8;
     
     /**
      * Create a new Dialog with a title and a message.


### PR DESCRIPTION
Marked the DEFAULT_TITLE field in the AWTErrorDialog class as final to ensure it cannot be modified externally, preventing potential security risks or accidental modifications.