### PR TITLE
🛠️ Fix: Prevent Exposure of Internal Representation in getInitialTransform()

### DIFF
--- a/jme3-core/src/main/java/com/jme3/anim/Joint.java
+++ b/jme3-core/src/main/java/com/jme3/anim/Joint.java
@@ -389,7 +389,7 @@ public class Joint implements Savable, JmeCloneable, HasLocalTransform {
      * @return the pre-existing instance
      */
     public Transform getInitialTransform() {
-        return initialTransform;
+        return new Transform(initialTransform);
     }
 
     /**


### PR DESCRIPTION
**Description:**

This PR addresses an issue where the getInitialTransform() method in Joint.java directly returns a reference to the mutable initialTransform field. This exposes the internal state of the object, allowing unintended modifications from external code.
To fix this, the method now returns a defensive copy of initialTransform, ensuring that the original object remains unchanged.

**Changes Made**

📌 File Modified: jme3-core/src/main/java/com/jme3/anim/Joint.java

**✅ Updated Code:**

<img width="558" alt="image" src="https://github.com/user-attachments/assets/09e0b8f0-b8e5-40b3-9cde-169d2274abcd" />

**Why This Fix?**

🔒 Prevents external modifications to initialTransform
🛠️ Improves encapsulation and security
✅ Ensures object integrity and avoids unintended side effects

**Impact of This Change**
	•	Ensures that any modifications to the returned Transform do not affect the internal state of the Joint object.
	•	Enhances code robustness and security best practices.

**Testing Done**
	•	Verified that getInitialTransform() still returns a valid Transform object.
	•	Ensured that modifications to the returned object do not affect the original initialTransform.
	•	Unit tests pass successfully.


